### PR TITLE
Include global scripts to enable payment simulator

### DIFF
--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -431,6 +431,7 @@ document.addEventListener('DOMContentLoaded', function(){
 {% endif %}
 
 <!-- Bloque para scripts específicos de cada página -->
+<script src="{% static 'js/scripts.js' %}"></script>
 {% block extra_scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load global `scripts.js` in layout so `openPaymentSimulator` is available

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a88ba68a1c832485f55d91a0f44fdf