### PR TITLE
style: add spacing in saldo_restante check

### DIFF
--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -120,7 +120,7 @@
                 <li class="d-flex justify-content-between"><span>Total Pagos (con imp.)</span><span class="mono">{{ total_pagado|ars }}</span></li>
                 <li class="d-flex justify-content-between">
                   <span>Saldo Restante</span>
-                  <span class="mono {% if saldo_restante>0 %}text-danger{% else %}text-success{% endif %}">{{ saldo_restante|ars }}</span>
+                  <span class="mono {% if saldo_restante > 0 %}text-danger{% else %}text-success{% endif %}">{{ saldo_restante|ars }}</span>
                 </li>
                 {% if cambio > 0 %}
                   <li class="d-flex justify-content-between text-muted"><span>Cambio</span><span class="mono">{{ cambio|ars }}</span></li>


### PR DESCRIPTION
## Summary
- ensure saldo_restante conditional has spaces around greater-than operator

## Testing
- `python manage.py test`
- `curl -L -s -o /tmp/simulador.html -w "%{http_code}" http://localhost:8000/simulador/`


------
https://chatgpt.com/codex/tasks/task_e_68a89351d3fc8324abe657cf9a659659