### PR TITLE
Open payment simulator in modal

### DIFF
--- a/core/static/css/styles.css
+++ b/core/static/css/styles.css
@@ -3879,3 +3879,46 @@ button.whatsapp-btn#whatsappBtn.fa-brands.fa-whatsapp:not(:visible)::after {
     padding: 6px 16px;
   }
 }
+
+.payment-simulator-modal {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.payment-simulator-modal .modal-dialog {
+  max-width: 900px;
+  width: 90%;
+}
+
+.payment-simulator-modal .modal-content {
+  background-color: var(--modal-bg);
+  color: var(--text-color);
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+}
+
+.payment-simulator-modal .modal-body {
+  padding: 0;
+  height: 80vh;
+}
+
+.payment-simulator-modal iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  transform: scale(0.9);
+  transform-origin: top left;
+}
+
+@media (max-width: 768px) {
+  .payment-simulator-modal .modal-dialog {
+    max-width: 100%;
+    margin: 0;
+  }
+  .payment-simulator-modal .modal-body {
+    height: 85vh;
+  }
+  .payment-simulator-modal iframe {
+    transform: scale(0.8);
+  }
+}

--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -2926,7 +2926,16 @@ async function generatePdfOnly() {
 function openPaymentSimulator() {
     const totalStr = document.getElementById('cartTotalFloat')?.textContent || '0';
     const total = parseFloat(totalStr.replace(/\./g, '').replace(',', '.')) || 0;
-    window.open(`/simulador/?total=${total}`, '_blank');
+    toggleCart();
+    const frame = document.getElementById('paymentSimulatorFrame');
+    if (frame) {
+        frame.src = `/simulador/?total=${total}`;
+        const modalEl = document.getElementById('paymentSimulatorModal');
+        const modal = new bootstrap.Modal(modalEl);
+        modal.show();
+    } else {
+        window.open(`/simulador/?total=${total}`, '_blank');
+    }
 }
 
 function toggleCartButtonDetails() {

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -382,6 +382,21 @@
   </div>
 </div>
 
+<!-- Modal Simulador de Pagos -->
+<div id="paymentSimulatorModal" class="modal fade payment-simulator-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header bg-dark text-white">
+        <h5 class="modal-title">Simulador de Pagos</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body p-0">
+        <iframe id="paymentSimulatorFrame"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Modal WhatsApp -->
 <div id="whatsappModal" class="modal fade" tabindex="-1" aria-labelledby="whatsappModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">

--- a/core/views.py
+++ b/core/views.py
@@ -918,7 +918,24 @@ def calcular_linea(importe: float, metodo: str, cuotas: int, promo_id: str) -> d
 
 @login_required
 def simulador_pagos(request):
-    total_carrito = 150000
+    user_id = request.session.get("email")
+    total_carrito = 0
+
+    # Intenta obtener el total del carrito guardado para el usuario
+    try:
+        if user_id:
+            cart_data = get_cart(user_id)
+            items = cart_data.get("cart", {}).get("items", [])
+            total_carrito = int(
+                sum(
+                    float(i.get("price", 0)) * float(i.get("quantity", 0))
+                    for i in items
+                    if i.get("productId")
+                )
+            )
+    except Exception:
+        total_carrito = 0
+
     sucursal = SUCURSALES[0]
 
     importes: List[float] = [75000]


### PR DESCRIPTION
## Summary
- Load cart total automatically for payment simulator
- Open payment simulator inside responsive modal with blur and scaling
- Update styles and script for modal-based simulator launch

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a89b7b30e48324acfa2cdf25d8bb67