### PR TITLE
feat: remove cart toggle on payment simulator

### DIFF
--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -2926,13 +2926,18 @@ async function generatePdfOnly() {
 function openPaymentSimulator() {
     const totalStr = document.getElementById('cartTotalFloat')?.textContent || '0';
     const total = parseFloat(totalStr.replace(/\./g, '').replace(',', '.')) || 0;
-    toggleCart();
     const frame = document.getElementById('paymentSimulatorFrame');
     if (frame) {
         frame.src = `/simulador/?total=${total}`;
         const modalEl = document.getElementById('paymentSimulatorModal');
         const modal = new bootstrap.Modal(modalEl);
         modal.show();
+        modalEl.addEventListener('hidden.bs.modal', () => {
+            const cartOverlay = document.getElementById('cartOverlay');
+            if (cartOverlay && !cartOverlay.classList.contains('d-none')) {
+                toggleCart();
+            }
+        }, { once: true });
     } else {
         window.open(`/simulador/?total=${total}`, '_blank');
     }


### PR DESCRIPTION
## Summary
- avoid closing cart when opening payment simulator
- close cart after simulator modal hides

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a8a69dc7f08324945517e2f12b34c7