### PR TITLE
Raise payment simulator modal z-index

### DIFF
--- a/core/static/css/styles.css
+++ b/core/static/css/styles.css
@@ -3883,6 +3883,7 @@ button.whatsapp-btn#whatsappBtn.fa-brands.fa-whatsapp:not(:visible)::after {
 .payment-simulator-modal {
   background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(4px);
+  z-index: 1200;
 }
 
 .payment-simulator-modal .modal-dialog {


### PR DESCRIPTION
## Summary
- elevate payment simulator modal above navbar by setting z-index to 1200

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a8a6bda3388324893c52a1872c4881