### PR TITLE
Fix modal overlapping navbar by adjusting z-index

### DIFF
--- a/core/static/css/styles.css
+++ b/core/static/css/styles.css
@@ -3883,6 +3883,7 @@ button.whatsapp-btn#whatsappBtn.fa-brands.fa-whatsapp:not(:visible)::after {
 .payment-simulator-modal {
   background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(4px);
+  z-index: 1200;
 }
 
 .payment-simulator-modal .modal-dialog {


### PR DESCRIPTION
## Summary
- ensure payment simulator modal overlays the navbar by giving it a higher z-index

## Testing
- `python -m pytest`
- `python - <<'PY'
from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto('http://localhost:8000/')
    nav_z = page.evaluate("getComputedStyle(document.querySelector('.navbar')).zIndex")
    modal_z = page.evaluate("(() => {const m=document.querySelector('.payment-simulator-modal'); return m?getComputedStyle(m).zIndex:null;})()")
    print('navbar z-index:', nav_z)
    print('modal z-index:', modal_z)
    browser.close()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8a6ee86e08324857012359be19b3b