### PR TITLE
Configure X-Frame-Options

### DIFF
--- a/buscador_django/settings.py
+++ b/buscador_django/settings.py
@@ -9,6 +9,9 @@ DEBUG = os.environ.get('DJANGO_DEBUG', '1') == '1'
 
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '').split() if not DEBUG else []
 
+# Controla si el sitio puede ser embebido en iframes
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
 # Apps
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
## Summary
- restrict iframe embedding by setting `X_FRAME_OPTIONS = 'SAMEORIGIN'`

## Testing
- `python manage.py test`
- `python manage.py runserver` (terminated)

------
https://chatgpt.com/codex/tasks/task_e_68a8a6eeeb1c83248992f3d124822d92