### PR TITLE
Make payment simulator standalone and blank by default

### DIFF
--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -1,20 +1,23 @@
-{% extends 'layout.html' %}
 {% load static %}
 {% load currency %}
-
-{% block title %}Simulador de Pagos{% endblock %}
-
-{% block extra_head %}
-<style>
-  body { background: linear-gradient(#f8fafc, #fff); }
-  .card { border-radius: 1rem; }
-  .badge-soft { background: #fff3cd; color: #b08900; }
-  .mono { font-variant-numeric: tabular-nums; }
-  .dashed { border-top: 1px dashed #cbd5e1; }
-</style>
-{% endblock %}
-
-{% block content %}
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Simulador de Pagos</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+    />
+    <style>
+      body { background: linear-gradient(#f8fafc, #fff); }
+      .card { border-radius: 1rem; }
+      .badge-soft { background: #fff3cd; color: #b08900; }
+      .mono { font-variant-numeric: tabular-nums; }
+      .dashed { border-top: 1px dashed #cbd5e1; }
+    </style>
+  </head>
+  <body>
 <div class="container py-4">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="h4 mb-0">🧮 Simulador de Pagos — Multipagos (Mock)</h1>
@@ -184,10 +187,8 @@
     </div>
   </form>
 </div>
-{% endblock %}
-
-{% block extra_scripts %}
-<script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
   let activeInput = null;
   function setActiveAmountInput(el){ activeInput = el; el.select(); }
   function parseNum(v){ const n = parseFloat((v||'').toString().replace(',', '.')) || 0; return Math.max(0, n); }
@@ -291,5 +292,6 @@
     if(sel.value === 'credito'){ cuotas.removeAttribute('disabled'); }
     else { cuotas.setAttribute('disabled',''); cuotas.value = '1'; }
   }
-</script>
-{% endblock %}
+    </script>
+  </body>
+</html>

--- a/core/views.py
+++ b/core/views.py
@@ -938,10 +938,10 @@ def simulador_pagos(request):
 
     sucursal = SUCURSALES[0]
 
-    importes: List[float] = [75000]
-    metodos: List[str] = ["debito"]
-    cuotas: List[int] = [1]
-    promos: List[str] = ["PROMO_BERCO10"]
+    importes: List[float] = []
+    metodos: List[str] = []
+    cuotas: List[int] = []
+    promos: List[str] = []
 
     if request.method == "POST":
         try:


### PR DESCRIPTION
## Summary
- make `simulador_pagos.html` a standalone page so iframes show only the simulator
- start `simulador_pagos` form lists empty to present a blank simulator

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a8aecb1e748324abbb3d9673ac6a31