### PR TITLE
Allow chip and saldo apply without prior focus

### DIFF
--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -194,12 +194,18 @@
   function getSaldoRestante(){ return parseNum("{{ saldo_restante }}"); }
   function applyChip(btn, pct){
     const total = parseNum(document.querySelector('[name="total_carrito"]').value);
-    if(!activeInput){ btn.closest('.row')?.querySelector('.amount-input')?.focus(); return; }
+    const input = btn.closest('.row')?.querySelector('.amount-input');
+    if(!input) return;
+    activeInput = input;
+    input.focus();
     const valor = Math.floor(total * pct);
     activeInput.value = valor;
   }
   function applySaldo(btn){
-    if(!activeInput){ btn.closest('.row')?.querySelector('.amount-input')?.focus(); return; }
+    const input = btn.closest('.row')?.querySelector('.amount-input');
+    if(!input) return;
+    activeInput = input;
+    input.focus();
     const saldo = getSaldoRestante();
     activeInput.value = Math.max(0, Math.floor(saldo));
   }


### PR DESCRIPTION
## Summary
- focus amount input when using chip/saldo buttons
- apply chip or remaining balance immediately to that input

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b1f6291083248f563a5c4082a01c