### PR TITLE
Handle monetary values as floats and remove Math.floor

### DIFF
--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -195,13 +195,14 @@
   function applyChip(btn, pct){
     const total = parseNum(document.querySelector('[name="total_carrito"]').value);
     if(!activeInput){ btn.closest('.row')?.querySelector('.amount-input')?.focus(); return; }
-    const valor = Math.floor(total * pct);
-    activeInput.value = valor;
+    const valor = parseFloat((total * pct).toFixed(2));
+    activeInput.value = valor.toFixed(2);
   }
   function applySaldo(btn){
     if(!activeInput){ btn.closest('.row')?.querySelector('.amount-input')?.focus(); return; }
     const saldo = getSaldoRestante();
-    activeInput.value = Math.max(0, Math.floor(saldo));
+    const valor = Math.max(0, parseFloat(saldo.toFixed(2)));
+    activeInput.value = valor.toFixed(2);
   }
   function keypad(key){
     if(!activeInput){ return; }
@@ -221,7 +222,8 @@
       const last = document.querySelectorAll('input[name="importe_pago[]"]');
       const exceso = suma - total;
       const nuevo = Math.max(0, parseNum(last[last.length-1].value) - exceso);
-      last[last.length-1].value = Math.floor(nuevo);
+      const valorAjustado = parseFloat(nuevo.toFixed(2));
+      last[last.length-1].value = valorAjustado.toFixed(2);
       setTimeout(()=>document.getElementById('form').requestSubmit(), 0);
     }
   });

--- a/core/views.py
+++ b/core/views.py
@@ -919,22 +919,23 @@ def calcular_linea(importe: float, metodo: str, cuotas: int, promo_id: str) -> d
 @login_required
 def simulador_pagos(request):
     user_id = request.session.get("email")
-    total_carrito = 0
+    total_carrito = 0.0
 
     # Intenta obtener el total del carrito guardado para el usuario
     try:
         if user_id:
             cart_data = get_cart(user_id)
             items = cart_data.get("cart", {}).get("items", [])
-            total_carrito = int(
+            total_carrito = round(
                 sum(
                     float(i.get("price", 0)) * float(i.get("quantity", 0))
                     for i in items
                     if i.get("productId")
-                )
+                ),
+                2,
             )
     except Exception:
-        total_carrito = 0
+        total_carrito = 0.0
 
     sucursal = SUCURSALES[0]
 
@@ -945,7 +946,9 @@ def simulador_pagos(request):
 
     if request.method == "POST":
         try:
-            total_carrito = int(float(request.POST.get("total_carrito", total_carrito)))
+            total_carrito = round(
+                float(request.POST.get("total_carrito", total_carrito)), 2
+            )
         except Exception:
             pass
         sucursal = request.POST.get("sucursal", sucursal)
@@ -957,7 +960,9 @@ def simulador_pagos(request):
     else:
         # Permite inicializar con total del carrito via querystring
         try:
-            total_carrito = int(float(request.GET.get("total", total_carrito)))
+            total_carrito = round(
+                float(request.GET.get("total", total_carrito)), 2
+            )
         except Exception:
             pass
 
@@ -978,8 +983,10 @@ def simulador_pagos(request):
         )
         total_pagado += r["total"]
 
-    saldo_restante = max(0.0, total_carrito - total_pagado)
-    cambio = max(0.0, total_pagado - total_carrito)
+    total_pagado = round(total_pagado, 2)
+
+    saldo_restante = round(max(0.0, total_carrito - total_pagado), 2)
+    cambio = round(max(0.0, total_pagado - total_carrito), 2)
 
     progress_pct = 0.0
     if total_carrito > 0:


### PR DESCRIPTION
## Summary
- Remove integer casting in payment simulator view and round monetary totals as floats
- Use decimal-friendly calculations in payment simulator template and format values to two decimals

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b1f6b8b8832494c7a9a3ef45cf42