### PR TITLE
Use lightweight template for simulador iframe

### DIFF
--- a/core/templates/simulador_base.html
+++ b/core/templates/simulador_base.html
@@ -1,0 +1,19 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}{% endblock %}</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+  {% block extra_head %}{% endblock %}
+</head>
+<body>
+  {% block content %}{% endblock %}
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{% static 'js/scripts.js' %}"></script>
+  {% block extra_scripts %}{% endblock %}
+</body>
+</html>

--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -1,4 +1,4 @@
-{% extends 'layout.html' %}
+{% extends 'simulador_base.html' %}
 {% load static %}
 {% load currency %}
 


### PR DESCRIPTION
## Summary
- add minimal `simulador_base.html` with just essential Bootstrap and styles
- have `simulador_pagos.html` extend the lightweight base for trimmed iframe output

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b1f820e483249bcea4311e98998c