### PR TITLE
Refactor simulador pagos template

### DIFF
--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -2,24 +2,20 @@
 
 {% load static %}
 {% load currency %}
-<!DOCTYPE html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Simulador de Pagos</title>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-    />
-    <style>
-      body { background: linear-gradient(#f8fafc, #fff); }
-      .card { border-radius: 1rem; }
-      .badge-soft { background: #fff3cd; color: #b08900; }
-      .mono { font-variant-numeric: tabular-nums; }
-      .dashed { border-top: 1px dashed #cbd5e1; }
-    </style>
-  </head>
-  <body>
+
+{% block title %}Simulador de Pagos{% endblock %}
+
+{% block extra_head %}
+<style>
+  body { background: linear-gradient(#f8fafc, #fff); }
+  .card { border-radius: 1rem; }
+  .badge-soft { background: #fff3cd; color: #b08900; }
+  .mono { font-variant-numeric: tabular-nums; }
+  .dashed { border-top: 1px dashed #cbd5e1; }
+</style>
+{% endblock %}
+
+{% block content %}
 <div class="container py-4">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="h4 mb-0">🧮 Simulador de Pagos — Multipagos (Mock)</h1>
@@ -189,3 +185,4 @@
     </div>
   </form>
 </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- remove duplicate HTML wrapper in the payment simulator template
- add title and content blocks with inline styles

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68a8ca1b54708324b8d98f9d031ec3cc