### PR TITLE
Format cart totals with decimals

### DIFF
--- a/core/templates/simulador_pagos.html
+++ b/core/templates/simulador_pagos.html
@@ -33,7 +33,7 @@
             <div class="row g-3 mt-1">
               <div class="col-md-4">
                 <label class="form-label">Total Carrito (ARS)</label>
-                <input type="number" class="form-control" name="total_carrito" value="{{ total_carrito }}" min="0" />
+                <input type="number" class="form-control" name="total_carrito" value="{{ total_carrito|floatformat:2 }}" step="0.01" min="0" />
               </div>
               <div class="col-md-4">
                 <label class="form-label">Sucursal</label>

--- a/core/templatetags/currency.py
+++ b/core/templatetags/currency.py
@@ -8,4 +8,6 @@ def ars(value):
         value = float(value)
     except (TypeError, ValueError):
         value = 0.0
-    return f"$ {value:,.0f}".replace(",", ".")
+    # Formatea con dos decimales y estilo argentino (separador de miles ".", decimales ",")
+    formatted = f"$ {value:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+    return formatted


### PR DESCRIPTION
## Summary
- format ARS currency values with two decimals
- allow entering cart total with decimal precision in payment simulator

## Testing
- `python -m py_compile core/templatetags/currency.py`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ac41df2dc483249bd58a9663a53524