### PR TITLE
Handle D365 token retrieval errors with Django JsonResponse

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -32,7 +32,7 @@ from services.fabric import (
     obtener_grupos_cumplimiento_fabric,
 )
 
-from services.get_token import get_access_token_d365
+from services.get_token import get_access_token_d365, TokenRetrievalError
 from services.database import guardar_token_d365
 from services.email_service import enviar_correo_fallo
 
@@ -170,9 +170,14 @@ def _run_step_chain(nombre: str, *fn_chain):
 
 def actualizar_token_d365():
     """Obtiene y persiste el token D365."""
-    token = get_access_token_d365()
+    try:
+        token = get_access_token_d365()
+    except TokenRetrievalError as exc:
+        logger.error(f"{FAIL} get_access_token_d365 falló: {exc}")
+        return
     if not token:
-        raise RuntimeError("No se pudo obtener token D365")
+        logger.error(f"{FAIL} No se pudo obtener token D365")
+        return
     guardar_token_d365(token)
     logger.info("Token D365 actualizado por bootstrap/cron.")
 

--- a/services/get_token.py
+++ b/services/get_token.py
@@ -2,7 +2,7 @@ import requests
 import configparser
 import os
 import logging
-from flask import jsonify
+from django.http import JsonResponse
 
 # Obtén la ruta absoluta a la raíz del proyecto
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -22,6 +22,15 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+
+
+class TokenRetrievalError(Exception):
+    """Error raised when D365 access token retrieval fails."""
+
+    def __init__(self, message: str = "No se pudo obtener la secuencia") -> None:
+        # Provide a JsonResponse for potential HTTP contexts
+        self.response = JsonResponse({"error": message}, status=500)
+        super().__init__(message)
 
 def load_d365_config():
 
@@ -65,7 +74,7 @@ def get_access_token_d365():
 
     except requests.RequestException as e:
         logging.error(f"Consulta token a D365 FALLO. {e}")
-        return jsonify({'error': 'No se pudo obtener la secuencia'}), 500
+        raise TokenRetrievalError() from e
 
 
 def get_access_token_d365_qa():
@@ -93,4 +102,4 @@ def get_access_token_d365_qa():
 
     except requests.RequestException as e:
         logging.error(f"Consulta token a D365 FALLO. {e}")
-        return jsonify({'error': 'No se pudo obtener la secuencia'}), 500
+        raise TokenRetrievalError() from e


### PR DESCRIPTION
## Summary
- Replace Flask's `jsonify` with Django `JsonResponse`
- Raise `TokenRetrievalError` when D365 token retrieval fails
- Catch `TokenRetrievalError` in scheduler to abort token update

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7f0f6f988324a99c404345aead50