### PR TITLE
feat: add ARCA invoicing service with dynamic OpenSSL path

### DIFF
--- a/services/modulo_facturacion_arca.py
+++ b/services/modulo_facturacion_arca.py
@@ -1,0 +1,14 @@
+import os
+import shutil
+import subprocess
+
+OPENSSL_BIN = os.getenv("OPENSSL_PATH") or shutil.which("openssl")
+if not OPENSSL_BIN:
+    raise RuntimeError(
+        "No se encontró el ejecutable de OpenSSL. Configure OPENSSL_PATH o añádalo al PATH."
+    )
+
+def ejecutar_openssl(*args: str) -> subprocess.CompletedProcess:
+    """Ejecuta OpenSSL con los argumentos proporcionados."""
+    cmd = [OPENSSL_BIN, *args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=True)


### PR DESCRIPTION
## Summary
- add `modulo_facturacion_arca` service resolving OpenSSL path via env or PATH
- provide helper to invoke OpenSSL without hardcoded paths

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68ac999243488324bcbd8a27cc3a3d19