### PR TITLE
Agrega utilitario para ejecutar OpenSSL con mensajes claros

### DIFF
--- a/services/openssl_utils.py
+++ b/services/openssl_utils.py
@@ -1,0 +1,40 @@
+import logging
+import os
+import subprocess
+from typing import List
+
+OPENSSL_BIN = os.environ.get("OPENSSL_BIN", "openssl")
+logger = logging.getLogger(__name__)
+
+def run_openssl(args: List[str]) -> str:
+    """Run an OpenSSL command and return its standard output.
+
+    All log messages explicitly mention the path used to invoke OpenSSL.
+
+    Parameters
+    ----------
+    args:
+        Additional command-line arguments passed to OpenSSL.
+    Returns
+    -------
+    str
+        The standard output produced by OpenSSL.
+    Raises
+    ------
+    RuntimeError
+        If OpenSSL fails to execute. The error message includes the
+        path to the binary used.
+    """
+    cmd = [OPENSSL_BIN, *args]
+    logger.info("Ejecutando OpenSSL en '%s' con argumentos: %s", OPENSSL_BIN, args)
+    try:
+        completed = subprocess.run(
+            cmd, check=True, text=True, capture_output=True
+        )
+        logger.info("OpenSSL ejecutado correctamente en '%s'", OPENSSL_BIN)
+        return completed.stdout
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        logger.error(
+            "Fallo al ejecutar OpenSSL en '%s': %s", OPENSSL_BIN, getattr(e, 'stderr', e)
+        )
+        raise RuntimeError(f"Error al ejecutar '{OPENSSL_BIN}': {e}") from e


### PR DESCRIPTION
## Summary
- Añade `run_openssl` para ejecutar OpenSSL y detallar la ruta utilizada en los logs
- Mejora el manejo de errores de OpenSSL incluyendo la ruta del binario en las excepciones

## Testing
- `pytest`
- `python -m py_compile services/openssl_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac9993b6048324a0b590c0c932edf1