### PR TITLE
docs: document OPENSSL_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# MyPOS_FBM
+
+## Configuración de OpenSSL
+
+La aplicación requiere acceso al binario de OpenSSL. Si `openssl` no se encuentra en el `PATH` del sistema, es necesario definir la variable de entorno `OPENSSL_PATH` apuntando a la ruta completa del ejecutable.
+
+Ejemplo en un archivo `.env`:
+
+```env
+OPENSSL_PATH=/usr/local/opt/openssl/bin/openssl
+```
+
+O definiendo la variable en el entorno del sistema:
+
+```bash
+export OPENSSL_PATH=/usr/local/opt/openssl/bin/openssl
+```
+
+Asegúrate de que la ruta coincida con la ubicación real del binario de OpenSSL en tu sistema.
+


### PR DESCRIPTION
## Summary
- document OPENSSL_PATH usage when OpenSSL isn't in PATH

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9993f8508324a16f5186f34f700e