### PR TITLE
Ensure database directories exist before SQLite connections

### DIFF
--- a/services/database.py
+++ b/services/database.py
@@ -54,6 +54,8 @@ def conectar_db(tabla):
     db_path = DB_PATHS.get(tabla)
     if not db_path:
         raise ValueError(f"No se encontró una base de datos para la tabla {tabla}")
+    # Asegurar que el directorio de la base de datos exista antes de conectar
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
     try:
         conexion = sqlite3.connect(db_path, timeout=10)
         conexion.execute("PRAGMA journal_mode=WAL;")


### PR DESCRIPTION
## Summary
- create database directory automatically before connecting to SQLite

## Testing
- `python manage.py migrate`
- `python - <<'PY'
from services.database import init_db
init_db()
PY`
- `python manage.py runserver 0.0.0.0:8000` *(terminated after confirming startup)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68adc20d31c88324a576b49f324b4f91