### PR TITLE
Use file-based sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,20 @@ export OPENSSL_PATH=/usr/local/opt/openssl/bin/openssl
 
 Asegúrate de que la ruta coincida con la ubicación real del binario de OpenSSL en tu sistema.
 
+## Configuración de sesiones
+
+El proyecto usa sesiones basadas en archivos para una mayor resiliencia. Por defecto se
+almacenan en el directorio `sessions/` que se crea automáticamente. Este directorio debe ser
+escribible y persistir durante el despliegue (por ejemplo, mediante un volumen). Puedes
+personalizar la ubicación con la variable de entorno `DJANGO_SESSION_FILE_PATH`.
+
+### Probar persistencia
+
+Para comprobar que las sesiones se guardan correctamente:
+
+```bash
+python manage.py shell -c "from django.contrib.sessions.backends.file import SessionStore; s=SessionStore(); s['ping']='pong'; s.save(); sid=s.session_key; s2=SessionStore(session_key=sid); print(s2['ping'])"
+```
+
+La salida debe mostrar `pong`.
+

--- a/buscador_django/settings.py
+++ b/buscador_django/settings.py
@@ -118,5 +118,9 @@ MESSAGE_TAGS = {
 }
 
 # Sesión
+SESSION_ENGINE = 'django.contrib.sessions.backends.file'
+SESSION_FILE_DIR = Path(os.environ.get('DJANGO_SESSION_FILE_PATH', BASE_DIR / 'sessions'))
+SESSION_FILE_DIR.mkdir(parents=True, exist_ok=True)
+SESSION_FILE_PATH = str(SESSION_FILE_DIR)
 SESSION_COOKIE_AGE = 60 * 60 * 4  # 4 horas
 SESSION_SAVE_EVERY_REQUEST = True


### PR DESCRIPTION
## Summary
- switch to file-based session backend for resilience and configurable directory
- document session storage setup and how to verify persistence

## Testing
- `python manage.py check`
- `python manage.py test`
- `python manage.py shell -c "from django.contrib.sessions.backends.file import SessionStore; s=SessionStore(); s['ping']='pong'; s.save(); sid=s.session_key; s2=SessionStore(session_key=sid); print(s2['ping'])"`


------
https://chatgpt.com/codex/tasks/task_e_68adc90366ec8324b8a7ecd0743be93b