### PR TITLE
Add session save error logging middleware

### DIFF
--- a/buscador_django/settings.py
+++ b/buscador_django/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'core.middleware.session_logging.SessionSaveLoggingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     # 'django.middleware.locale.LocaleMiddleware',  # si necesitas i18n por sitios, actívalo
     'django.middleware.common.CommonMiddleware',

--- a/core/middleware/__init__.py
+++ b/core/middleware/__init__.py
@@ -1,0 +1,1 @@
+# core/middleware/__init__.py

--- a/core/middleware/session_logging.py
+++ b/core/middleware/session_logging.py
@@ -1,0 +1,27 @@
+# core/middleware/session_logging.py
+import logging
+from django.db.utils import OperationalError
+
+logger = logging.getLogger(__name__)
+
+class SessionSaveLoggingMiddleware:
+    """Log context on OperationalError during session save."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            return self.get_response(request)
+        except OperationalError as exc:
+            user = getattr(request, 'user', None)
+            username = (
+                user.username if getattr(user, 'is_authenticated', False) else 'Anonymous'
+            )
+            logger.error(
+                'Session save failed on %s for user %s: %s',
+                request.path,
+                username,
+                exc,
+            )
+            raise


### PR DESCRIPTION
## Summary
- add middleware wrapping session save to log OperationalError details
- register logging middleware before Django's SessionMiddleware

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68adc904207c8324818dbe76a34c80e3