### PR TITLE
Agregar vistas CRUD para Modos de Entrega

### DIFF
--- a/core/templates/config/modos_entrega/confirm_delete.html
+++ b/core/templates/config/modos_entrega/confirm_delete.html
@@ -1,0 +1,13 @@
+{% extends 'layout.html' %}
+{% block title %}Eliminar modo de entrega{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>Eliminar modo de entrega</h1>
+  <p>¿Estás seguro de que deseas eliminar "{{ modo.nombre }}"?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+    <a href="{% url 'core:modo_entrega_list' %}" class="btn btn-secondary">Cancelar</a>
+  </form>
+</div>
+{% endblock %}

--- a/core/templates/config/modos_entrega/form.html
+++ b/core/templates/config/modos_entrega/form.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+{% block title %}{{ titulo }}{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>{{ titulo }}</h1>
+  <form method="post">
+    {% csrf_token %}
+    <div class="mb-3">
+      {{ form.nombre.label_tag }}
+      {{ form.nombre }}
+      {% if form.nombre.errors %}
+      <div class="text-danger">{{ form.nombre.errors }}</div>
+      {% endif %}
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{% url 'core:modo_entrega_list' %}" class="btn btn-secondary">Cancelar</a>
+  </form>
+</div>
+{% endblock %}

--- a/core/templates/config/modos_entrega/list.html
+++ b/core/templates/config/modos_entrega/list.html
@@ -1,0 +1,31 @@
+{% extends 'layout.html' %}
+{% block title %}Modos de entrega{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>Modos de entrega</h1>
+  <a class="btn btn-primary mb-3" href="{% url 'core:modo_entrega_create' %}">Nuevo</a>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Nombre</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for modo in modos %}
+      <tr>
+        <td>{{ modo.nombre }}</td>
+        <td class="text-end">
+          <a class="btn btn-sm btn-secondary" href="{% url 'core:modo_entrega_update' modo.id %}">Editar</a>
+          <a class="btn btn-sm btn-danger" href="{% url 'core:modo_entrega_delete' modo.id %}">Eliminar</a>
+        </td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="2" class="text-center">No hay modos de entrega.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -38,4 +38,10 @@ urlpatterns = [
 
     path('api/save_user_cart', views.api_save_user_cart, name='api_save_user_cart'),
     path('api/get_user_cart', views.api_get_user_cart, name='api_get_user_cart'),
+
+    # Configuración - Modos de entrega
+    path('config/modos-entrega/', views.modo_entrega_list, name='modo_entrega_list'),
+    path('config/modos-entrega/nuevo/', views.modo_entrega_create, name='modo_entrega_create'),
+    path('config/modos-entrega/<int:pk>/editar/', views.modo_entrega_update, name='modo_entrega_update'),
+    path('config/modos-entrega/<int:pk>/eliminar/', views.modo_entrega_delete, name='modo_entrega_delete'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -7,12 +7,15 @@ from datetime import timezone, timedelta
 from typing import List, Dict
 
 from django.conf import settings
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.urls import reverse
+from django import forms
+
+from .models import ModoEntrega
 
 import pyarrow.compute as pc
 
@@ -55,6 +58,15 @@ from .scheduler import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class ModoEntregaForm(forms.ModelForm):
+    class Meta:
+        model = ModoEntrega
+        fields = ["nombre"]
+        widgets = {
+            "nombre": forms.TextInput(attrs={"class": "form-control"})
+        }
 
 # ======== Raíz ========
 @login_required
@@ -1013,4 +1025,67 @@ def simulador_pagos(request):
             "ahora": datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S"),
             "teclado_rows": TECLADO_ROWS,
         },
+    )
+
+
+# ======== CRUD Modos de Entrega ========
+
+
+@login_required
+@permission_required("core.view_modoentrega", raise_exception=True)
+def modo_entrega_list(request):
+    modos = ModoEntrega.objects.all()
+    return render(
+        request,
+        "config/modos_entrega/list.html",
+        {"modos": modos},
+    )
+
+
+@login_required
+@permission_required("core.add_modoentrega", raise_exception=True)
+def modo_entrega_create(request):
+    if request.method == "POST":
+        form = ModoEntregaForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("core:modo_entrega_list")
+    else:
+        form = ModoEntregaForm()
+    return render(
+        request,
+        "config/modos_entrega/form.html",
+        {"form": form, "titulo": "Nuevo modo de entrega"},
+    )
+
+
+@login_required
+@permission_required("core.change_modoentrega", raise_exception=True)
+def modo_entrega_update(request, pk):
+    modo = get_object_or_404(ModoEntrega, pk=pk)
+    if request.method == "POST":
+        form = ModoEntregaForm(request.POST, instance=modo)
+        if form.is_valid():
+            form.save()
+            return redirect("core:modo_entrega_list")
+    else:
+        form = ModoEntregaForm(instance=modo)
+    return render(
+        request,
+        "config/modos_entrega/form.html",
+        {"form": form, "titulo": "Editar modo de entrega"},
+    )
+
+
+@login_required
+@permission_required("core.delete_modoentrega", raise_exception=True)
+def modo_entrega_delete(request, pk):
+    modo = get_object_or_404(ModoEntrega, pk=pk)
+    if request.method == "POST":
+        modo.delete()
+        return redirect("core:modo_entrega_list")
+    return render(
+        request,
+        "config/modos_entrega/confirm_delete.html",
+        {"modo": modo},
     )


### PR DESCRIPTION
## Summary
- Añadidas vistas con permisos para listar, crear, editar y eliminar `ModoEntrega`
- Configuradas rutas bajo `config/modos-entrega/`
- Diseñadas plantillas basadas en `layout.html`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68adfe9013308324bdbd4812dcc9665d