### PR TITLE
Add TipoContribuyente admin CRUD

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,0 +1,20 @@
+from django import forms
+from .models import TipoContribuyente
+
+class TipoContribuyenteForm(forms.ModelForm):
+    class Meta:
+        model = TipoContribuyente
+        fields = ['nombre', 'codigo_arca']
+        widgets = {
+            'nombre': forms.TextInput(attrs={'class': 'form-control'}),
+            'codigo_arca': forms.TextInput(attrs={'class': 'form-control'}),
+        }
+
+    def clean_codigo_arca(self):
+        codigo = self.cleaned_data['codigo_arca']
+        qs = TipoContribuyente.objects.filter(codigo_arca=codigo)
+        if self.instance.pk:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise forms.ValidationError('Este código ya está en uso.')
+        return codigo

--- a/core/templates/config/tipos_contribuyente/confirm_delete.html
+++ b/core/templates/config/tipos_contribuyente/confirm_delete.html
@@ -1,0 +1,13 @@
+{% extends 'layout.html' %}
+{% block title %}Eliminar Tipo de contribuyente{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>Eliminar Tipo de contribuyente</h1>
+  <p>¿Seguro que desea eliminar "{{ tipo }}"?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Eliminar</button>
+    <a href="{% url 'core:tipos_contribuyente_list' %}" class="btn btn-secondary">Cancelar</a>
+  </form>
+</div>
+{% endblock %}

--- a/core/templates/config/tipos_contribuyente/form.html
+++ b/core/templates/config/tipos_contribuyente/form.html
@@ -1,0 +1,23 @@
+{% extends 'layout.html' %}
+{% block title %}{% if form.instance.pk %}Editar{% else %}Nuevo{% endif %} Tipo de contribuyente{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>{% if form.instance.pk %}Editar{% else %}Nuevo{% endif %} Tipo de contribuyente</h1>
+  <form method="post">
+    {% csrf_token %}
+    <div class="mb-3">
+      {{ form.nombre.label_tag }}
+      {{ form.nombre }}
+      {% for error in form.nombre.errors %}<div class="text-danger">{{ error }}</div>{% endfor %}
+    </div>
+    <div class="mb-3">
+      {{ form.codigo_arca.label_tag }}
+      {{ form.codigo_arca }}
+      {% for error in form.codigo_arca.errors %}<div class="text-danger">{{ error }}</div>{% endfor %}
+    </div>
+    {% if form.non_field_errors %}<div class="mb-3 text-danger">{{ form.non_field_errors }}</div>{% endif %}
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{% url 'core:tipos_contribuyente_list' %}" class="btn btn-secondary">Cancelar</a>
+  </form>
+</div>
+{% endblock %}

--- a/core/templates/config/tipos_contribuyente/list.html
+++ b/core/templates/config/tipos_contribuyente/list.html
@@ -1,0 +1,31 @@
+{% extends 'layout.html' %}
+{% block title %}Tipos de contribuyente{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>Tipos de contribuyente</h1>
+  <a href="{% url 'core:tipos_contribuyente_create' %}" class="btn btn-primary mb-3">Nuevo</a>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Nombre</th>
+        <th>Código ARCA</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for tipo in tipos %}
+      <tr>
+        <td>{{ tipo.nombre }}</td>
+        <td>{{ tipo.codigo_arca }}</td>
+        <td>
+          <a href="{% url 'core:tipos_contribuyente_update' tipo.pk %}" class="btn btn-sm btn-secondary">Editar</a>
+          <a href="{% url 'core:tipos_contribuyente_delete' tipo.pk %}" class="btn btn-sm btn-danger">Eliminar</a>
+        </td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="3">No hay tipos de contribuyente.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -38,4 +38,10 @@ urlpatterns = [
 
     path('api/save_user_cart', views.api_save_user_cart, name='api_save_user_cart'),
     path('api/get_user_cart', views.api_get_user_cart, name='api_get_user_cart'),
+
+    # Configuración ARCA
+    path('config/arca/tipos-contribuyente/', views.tipos_contribuyente_list, name='tipos_contribuyente_list'),
+    path('config/arca/tipos-contribuyente/nuevo/', views.tipos_contribuyente_create, name='tipos_contribuyente_create'),
+    path('config/arca/tipos-contribuyente/<int:pk>/editar/', views.tipos_contribuyente_update, name='tipos_contribuyente_update'),
+    path('config/arca/tipos-contribuyente/<int:pk>/eliminar/', views.tipos_contribuyente_delete, name='tipos_contribuyente_delete'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -7,12 +7,15 @@ from datetime import timezone, timedelta
 from typing import List, Dict
 
 from django.conf import settings
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required
+from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import reverse
+from .models import TipoContribuyente
+from .forms import TipoContribuyenteForm
 
 import pyarrow.compute as pc
 
@@ -55,6 +58,46 @@ from .scheduler import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ======== Config: Tipos de contribuyente ========
+@staff_member_required
+def tipos_contribuyente_list(request):
+    tipos = TipoContribuyente.objects.all()
+    return render(request, 'config/tipos_contribuyente/list.html', {'tipos': tipos})
+
+
+@staff_member_required
+def tipos_contribuyente_create(request):
+    if request.method == 'POST':
+        form = TipoContribuyenteForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('core:tipos_contribuyente_list')
+    else:
+        form = TipoContribuyenteForm()
+    return render(request, 'config/tipos_contribuyente/form.html', {'form': form})
+
+
+@staff_member_required
+def tipos_contribuyente_update(request, pk):
+    tipo = get_object_or_404(TipoContribuyente, pk=pk)
+    if request.method == 'POST':
+        form = TipoContribuyenteForm(request.POST, instance=tipo)
+        if form.is_valid():
+            form.save()
+            return redirect('core:tipos_contribuyente_list')
+    else:
+        form = TipoContribuyenteForm(instance=tipo)
+    return render(request, 'config/tipos_contribuyente/form.html', {'form': form, 'tipo': tipo})
+
+
+@staff_member_required
+def tipos_contribuyente_delete(request, pk):
+    tipo = get_object_or_404(TipoContribuyente, pk=pk)
+    if request.method == 'POST':
+        tipo.delete()
+        return redirect('core:tipos_contribuyente_list')
+    return render(request, 'config/tipos_contribuyente/confirm_delete.html', {'tipo': tipo})
 
 # ======== Raíz ========
 @login_required


### PR DESCRIPTION
## Summary
- add admin-protected CRUD views and routes for `TipoContribuyente`
- validate unique `codigo_arca` in the form
- provide templates for listing, form, and delete confirmation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'apscheduler')*


------
https://chatgpt.com/codex/tasks/task_e_68adfe90553483248a7dfb2f0b474e94