### PR TITLE
Ampliar carrito a pantalla completa con selector de envío

### DIFF
--- a/core/static/css/styles.css
+++ b/core/static/css/styles.css
@@ -1073,14 +1073,14 @@ body {
 
 .cart-container {
   background: var(--cart-bg);
-  border-radius: 8px;
-  width: 95vw;
-  height: 90vh;
+  border-radius: 0;
+  width: 100vw;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
   font-size: 0.75rem;
-  max-width: 900px;
+  max-width: none;
   position: relative;
   color: var(--text-color);
   transition: background-color 0.3s ease;
@@ -1110,7 +1110,14 @@ body {
 .cart-footer .observations-wrapper {
   display: flex;
   align-items: center;
-  width: 65%;
+  width: 50%;
+  flex-grow: 1;
+}
+
+.cart-footer .shipping-wrapper {
+  display: flex;
+  align-items: center;
+  width: 25%;
 }
 
 .cart-footer .observations-wrapper label {
@@ -1140,6 +1147,23 @@ body {
   color: var(--icon-color) !important;
   opacity: 0.7;
   transition: color 0.3s ease;
+}
+
+.cart-footer .shipping-wrapper label {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  color: var(--text-color) !important;
+  transition: color 0.3s ease;
+  margin-right: 8px;
+}
+
+.cart-footer .shipping-wrapper select {
+  font-size: 0.7rem;
+  height: 30px;
+  border-radius: 4px;
+  background-color: var(--input-bg) !important;
+  color: var(--text-color) !important;
+  border: 1px solid var(--input-border) !important;
 }
 
 .cart-footer .total-wrapper {
@@ -1561,8 +1585,8 @@ body {
   }
 
   .cart-container {
-    width: 95vw;
-    height: 90vh;
+    width: 100vw;
+    height: 100vh;
   }
 
   .cart-content {
@@ -1573,7 +1597,8 @@ body {
     padding: 10px 15px;
   }
 
-  .cart-footer .observations-wrapper {
+  .cart-footer .observations-wrapper,
+  .cart-footer .shipping-wrapper {
     width: 100%;
     margin-bottom: 10px;
   }

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -186,6 +186,14 @@
     <!-- Footer total -->
     <div class="cart-footer bg-light p-3 border-top">
       <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div class="shipping-wrapper">
+          <label for="shippingType" class="fw-bold me-2">Envío:</label>
+          <select id="shippingType" class="form-select form-select-sm">
+            <option value="" selected disabled>Seleccione...</option>
+            <option value="pickup">Retiro en tienda</option>
+            <option value="delivery">Envío a domicilio</option>
+          </select>
+        </div>
         <div class="observations-wrapper flex-grow-1">
           <label for="cartObservations" class="fw-bold me-2">Observaciones:</label>
           <textarea id="cartObservations" class="form-control form-control-sm" maxlength="180" placeholder="Ingrese observaciones (máx. 180 caracteres)" rows="1"></textarea>


### PR DESCRIPTION
## Resumen
- Carrito ocupa toda la pantalla para aprovechar el espacio disponible.
- Agregado selector de tipo de envío en el pie del carrito con estilos responsivos.

## Pruebas
- `python manage.py test` (sin pruebas encontradas)


------
https://chatgpt.com/codex/tasks/task_e_68ae0b7e5c288324b248dfd8d309735c