### PR TITLE
Ensure cart overlay uses full viewport

### DIFF
--- a/core/static/css/styles.css
+++ b/core/static/css/styles.css
@@ -1038,8 +1038,10 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
   background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(4px);
   display: flex;


### PR DESCRIPTION
## Summary
- enforce cart overlay width/height to fill entire viewport
- confirm cart container uses full viewport dimensions

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68ae114fe07c8324ac830853b1871feb