### PR TITLE
Prevent cart closure on payment simulator exit

### DIFF
--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -3025,12 +3025,6 @@ function openPaymentSimulator() {
         const modalEl = document.getElementById('paymentSimulatorModal');
         const modal = new bootstrap.Modal(modalEl);
         modal.show();
-        modalEl.addEventListener('hidden.bs.modal', () => {
-            const cartOverlay = document.getElementById('cartOverlay');
-            if (cartOverlay && !cartOverlay.classList.contains('d-none')) {
-                toggleCart();
-            }
-        }, { once: true });
     } else {
         window.open(`/simulador/?total=${total}`, '_blank');
     }


### PR DESCRIPTION
## Summary
- avoid toggling cart overlay when the payment simulator modal closes

## Testing
- `pytest`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3743f354832493da2e69818dc40a