### PR TITLE
Expose simulator functions and defer script loading

### DIFF
--- a/core/static/js/simulador_pagos.js
+++ b/core/static/js/simulador_pagos.js
@@ -118,3 +118,13 @@ function toggleCuotas(sel) {
         cuotas.value = '1';
     }
 }
+
+// Expose functions used in inline handlers
+window.setActiveAmountInput = setActiveAmountInput;
+window.applyChip = applyChip;
+window.applySaldo = applySaldo;
+window.keypad = keypad;
+window.applyEnter = applyEnter;
+window.agregarLinea = agregarLinea;
+window.eliminarLinea = eliminarLinea;
+window.toggleCuotas = toggleCuotas;

--- a/core/templates/simulador_base.html
+++ b/core/templates/simulador_base.html
@@ -13,7 +13,7 @@
 <body>
   {% block content %}{% endblock %}
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="{% static 'js/simulador_pagos.js' %}"></script>
+  <script src="{% static 'js/simulador_pagos.js' %}" defer></script>
   {% block extra_scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load `simulador_pagos.js` with `defer` to ensure execution after DOM parsing
- Expose simulator payment helpers on `window` so inline handlers work reliably

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ae3744da6c832488caa347761f2912