### PR TITLE
Render cart delivery modes dynamically

### DIFF
--- a/buscador_django/settings.py
+++ b/buscador_django/settings.py
@@ -53,6 +53,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'core.context_processors.modos_entrega',
             ],
         },
     },

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,5 @@
+from .models import ModoEntrega
+
+def modos_entrega(request):
+    """Provide all delivery modes for templates."""
+    return {'modos_entrega': ModoEntrega.objects.all()}

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -190,8 +190,9 @@
           <label for="shippingType" class="fw-bold me-2">Envío:</label>
           <select id="shippingType" class="form-select form-select-sm">
             <option value="" selected disabled>Seleccione...</option>
-            <option value="pickup">Retiro en tienda</option>
-            <option value="delivery">Envío a domicilio</option>
+            {% for modo in modos_entrega %}
+            <option value="{{ modo.id }}">{{ modo.nombre }}</option>
+            {% endfor %}
           </select>
         </div>
         <div class="observations-wrapper flex-grow-1">


### PR DESCRIPTION
## Summary
- add context processor that loads all `ModoEntrega`
- update settings to use the new context processor
- render shipping options from database in cart overlay

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3c8a74e883248cb49822c47620f8