### PR TITLE
Remove unused shipping selector from cart

### DIFF
--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -88,14 +88,12 @@ let cart = {
     client: null,
     quotation_id: null,
     type: 'new',
-    observations: '',
-    shipping_type: ''
+    observations: ''
 }; // Array para almacenar los ítems del carrito
 let currentProductToAdd = null; // Producto seleccionado para agregar al carrito
 let selectedClient = null;
 let lastProductsUpdate = 0;
 let cartObservations = "";
-let cartShippingType = "";
 let db;
 const DB_NAME = 'CartDB';
 const DB_VERSION = 1;
@@ -1367,23 +1365,6 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
-    const shippingSelect = document.getElementById("shippingType");
-    if (shippingSelect) {
-        shippingSelect.addEventListener("change", function (e) {
-            cartShippingType = e.target.value;
-            cart.shipping_type = cartShippingType;
-            const timestamp = new Date().toISOString();
-            getUserId().then(userId => {
-                Promise.all([
-                    saveCartToIndexedDB(userId, cart, timestamp),
-                    syncCartWithBackend(userId, cart, timestamp)
-                ]).catch(error => {
-                    console.error('Error al guardar tipo de envío:', error);
-                    showToast('danger', 'Error al guardar tipo de envío');
-                });
-            });
-        });
-    }
 });
 
 async function updateCartPrices(storeId) {
@@ -1839,7 +1820,6 @@ function updateCartDisplay() {
     const cartClientInfo = document.getElementById("cartClientInfo");
     let cartClientFloat = document.getElementById("cartClientFloat");
     const observationsInput = document.getElementById("cartObservations");
-    const shippingSelect = document.getElementById("shippingType");
 
     if (!cartTotalFixed) {
         console.error("Elemento 'cartTotalFixed' no encontrado en el DOM");
@@ -1855,10 +1835,6 @@ function updateCartDisplay() {
 
     if (observationsInput) {
         cartObservations = sanitizeText(observationsInput.value);
-    }
-    if (shippingSelect) {
-        cartShippingType = shippingSelect.value;
-        cart.shipping_type = cartShippingType;
     }
 
     if (!cartClientFloat) {
@@ -1934,9 +1910,6 @@ function updateCartDisplay() {
             }
             if (observationsInput) {
                 observationsInput.value = cartObservations;
-            }
-            if (shippingSelect) {
-                shippingSelect.value = cartShippingType;
             }
             return;
         }
@@ -2050,9 +2023,6 @@ function updateCartDisplay() {
         if (observationsInput) {
             observationsInput.value = cartObservations;
         }
-        if (shippingSelect) {
-            shippingSelect.value = cartShippingType;
-        }
 
     }
 }
@@ -2157,15 +2127,11 @@ function clearCart() {
         client: null,
         quotation_id: null,
         type: 'new',
-        observations: '',
-        shipping_type: ''
+        observations: ''
     };
     cartObservations = '';
-    cartShippingType = '';
     const obsInputReset = document.getElementById("cartObservations");
     if (obsInputReset) obsInputReset.value = '';
-    const shippingSelectReset = document.getElementById("shippingType");
-    if (shippingSelectReset) shippingSelectReset.value = '';
     const timestamp = new Date().toISOString();
     getUserId().then(userId => {
         Promise.all([
@@ -2297,8 +2263,7 @@ async function createInD365WithType(tipo_presupuesto) {
             cart: {
                 items: cart.items.filter(item => item.productId),
                 client: cart.client || {},
-                observations: cartObservations,
-                shipping_type: cartShippingType
+                observations: cartObservations
             },
             store_id: storeId,
             tipo_presupuesto: tipo_presupuesto
@@ -3015,7 +2980,6 @@ async function generatePdfOnly() {
             client: cart.client || null,
             items: cart.items.filter(item => item.productId),
             observations: cartObservations,
-            shipping_type: cartShippingType,
             timestamp: new Date().toISOString()
         };
 
@@ -3657,8 +3621,7 @@ async function loadQuotation(quotationId, type) {
             client: quotation.client || null,
             quotation_id: quotation.quotation_id || null,
             type: quotation.quotation_id ? type : 'new',
-            observations: quotation.observations || '',
-            shipping_type: quotation.shipping_type || ''
+            observations: quotation.observations || ''
         };
         // Mapear ítems directamente
         const itemsWithNumericPrices = (quotation.items || []).map(item => ({
@@ -3679,17 +3642,11 @@ async function loadQuotation(quotationId, type) {
             quotation_id: quotation.quotation_id || null,
             type: quotation.quotation_id ? type : 'new',
             observations: quotation.observations || '',
-            shipping_type: quotation.shipping_type || ''
         };
         cartObservations = cart.observations;
-        cartShippingType = cart.shipping_type || '';
         const observationsInput = document.getElementById("cartObservations");
         if (observationsInput) {
             observationsInput.value = cartObservations;
-        }
-        const shippingSelect = document.getElementById("shippingType");
-        if (shippingSelect) {
-            shippingSelect.value = cartShippingType;
         }
 
         // Actualizar el filtro de tienda
@@ -4237,11 +4194,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (localData && localData.cart) {
                 cart = localData.cart;
                 cartObservations = cart.observations || '';
-                cartShippingType = cart.shipping_type || '';
                 const obsInput = document.getElementById("cartObservations");
                 if (obsInput) obsInput.value = cartObservations;
-                const shipInput = document.getElementById("shippingType");
-                if (shipInput) shipInput.value = cartShippingType;
                 updateCartDisplay();
             }
             return;
@@ -4261,7 +4215,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 await syncCartWithBackend(userId, cart, timestamp);
             } else {
                 // Si no hay datos locales, usar carrito vacío
-                cart = { items: [], client: null, quotation_id: null, type: 'new', observations: '', shipping_type: '' };
+                cart = { items: [], client: null, quotation_id: null, type: 'new', observations: '' };
                 const timestamp = new Date().toISOString();
                 await saveCartToIndexedDB(userId, cart, timestamp);
                 await syncCartWithBackend(userId, cart, timestamp);
@@ -4269,23 +4223,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         cartObservations = cart.observations || '';
-        cartShippingType = cart.shipping_type || '';
         const obsInput = document.getElementById("cartObservations");
         if (obsInput) obsInput.value = cartObservations;
-        const shipInput = document.getElementById("shippingType");
-        if (shipInput) shipInput.value = cartShippingType;
         updateCartDisplay();
     } catch (error) {
         console.error('Error al inicializar el carrito:', error);
         showToast('danger', 'Error al cargar el carrito');
         // Usar carrito vacío como última opción
-        cart = { items: [], client: null, quotation_id: null, type: 'new', observations: '', shipping_type: '' };
+        cart = { items: [], client: null, quotation_id: null, type: 'new', observations: '' };
         cartObservations = '';
-        cartShippingType = '';
         const obsInputFallback = document.getElementById("cartObservations");
         if (obsInputFallback) obsInputFallback.value = cartObservations;
-        const shipInputFallback = document.getElementById("shippingType");
-        if (shipInputFallback) shipInputFallback.value = cartShippingType;
         updateCartDisplay();
     }
 });

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -186,15 +186,6 @@
     <!-- Footer total -->
     <div class="cart-footer bg-light p-3 border-top">
       <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <div class="shipping-wrapper">
-          <label for="shippingType" class="fw-bold me-2">Envío:</label>
-          <select id="shippingType" class="form-select form-select-sm">
-            <option value="" selected disabled>Seleccione...</option>
-            {% for modo in modos_entrega %}
-            <option value="{{ modo.id }}">{{ modo.nombre }}</option>
-            {% endfor %}
-          </select>
-        </div>
         <div class="observations-wrapper flex-grow-1">
           <label for="cartObservations" class="fw-bold me-2">Observaciones:</label>
           <textarea id="cartObservations" class="form-control form-control-sm" maxlength="180" placeholder="Ingrese observaciones (máx. 180 caracteres)" rows="1"></textarea>


### PR DESCRIPTION
## Summary
- remove shipping selector and related state from cart logic
- clean up cart overlay to omit shipping options

## Testing
- `node --check core/static/js/scripts.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ae435f2cec832490cee494155b3ee2