### PR TITLE
Align cart columns with reference layout

### DIFF
--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -1899,7 +1899,7 @@ function updateCartDisplay() {
 
         if (!cart.items || !Array.isArray(cart.items)) {
             console.error('cart.items no está definido o no es un array:', cart.items);
-            cartItemsDesktop.innerHTML = '<tr><td colspan="6" class="text-muted">El carrito está vacío o no se pudo cargar.</td></tr>';
+            cartItemsDesktop.innerHTML = '<tr><td colspan="8" class="text-muted">El carrito está vacío o no se pudo cargar.</td></tr>';
             cartItemsMobile.innerHTML = '<p class="text-muted">El carrito está vacío o no se pudo cargar.</p>';
             cartTotalFixed.textContent = '$0,00';
             if (cartTotalFloat) {
@@ -1938,6 +1938,14 @@ function updateCartDisplay() {
                             <span style="flex: 1; text-align: right;">${item.productName} ${availabilityText}</span>
                         </div>
                         <div class="cart-row-item d-flex justify-content-between" style="width: 100%; padding: 5px 0;">
+                            <span style="font-weight: 600; min-width: 100px;"><strong>Unidad:</strong></span>
+                            <span style="flex: 1; text-align: right;">${item.unidadMedida || ''}</span>
+                        </div>
+                        <div class="cart-row-item d-flex justify-content-between" style="width: 100%; padding: 5px 0;">
+                            <span style="font-weight: 600; min-width: 100px;"><strong>Factor:</strong></span>
+                            <span style="flex: 1; text-align: right;">${item.multiplo !== undefined && item.multiplo !== null ? Number(item.multiplo).toFixed(2) : ''}</span>
+                        </div>
+                        <div class="cart-row-item d-flex justify-content-between" style="width: 100%; padding: 5px 0;">
                             <span style="font-weight: 600; min-width: 100px;"><strong>Precio:</strong></span>
                             <span style="flex: 1; text-align: right;">${item.available !== false ? '$' + formatearMoneda(item.price) : 'N/A'}</span>
                         </div>
@@ -1961,7 +1969,6 @@ function updateCartDisplay() {
                                         <i class="bi bi-dash"></i>
                                     </button>
                                     <input type="number" class="form-control text-center cart-quantity-input" value="${item.quantity.toFixed(2)}" min="${item.multiplo}" step="${item.multiplo}" onchange="updateCartQuantity(${index}, this.value)" ${disabledAttr}>
-                                    <span class="input-group-text">${item.unidadMedida || ''}</span>
                                     <button class="btn btn-outline-secondary" onclick="adjustCartQuantity(${index}, 1)" ${disabledAttr}>
                                         <i class="bi bi-plus"></i>
                                     </button>
@@ -1977,6 +1984,8 @@ function updateCartDisplay() {
                     row.innerHTML = `
                         <td>${item.productId}</td>
                         <td>${item.productName} ${availabilityText}</td>
+                        <td>${item.unidadMedida || ''}</td>
+                        <td>${item.multiplo !== undefined && item.multiplo !== null ? Number(item.multiplo).toFixed(2) : ''}</td>
                         <td class="cart-quantity">
                             <div class="quantity-wrapper">
                                 <div class="input-group input-group-sm">
@@ -1984,7 +1993,6 @@ function updateCartDisplay() {
                                         <i class="bi bi-dash"></i>
                                     </button>
                                     <input type="number" class="form-control text-center cart-quantity-input" value="${item.quantity.toFixed(2)}" min="${item.multiplo}" step="${item.multiplo}" onchange="updateCartQuantity(${index}, this.value)" ${disabledAttr}>
-                                    <span class="input-group-text">${item.unidadMedida || ''}</span>
                                     <button class="btn btn-outline-secondary" onclick="adjustCartQuantity(${index}, 1)" ${disabledAttr}>
                                         <i class="bi bi-plus"></i>
                                     </button>

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -172,7 +172,14 @@
         <table class="table table-hover cart-table-desktop">
           <thead class="bg-light">
             <tr>
-              <th>SKU</th><th>Producto</th><th>Cant.</th><th>Precio</th><th>Total</th><th></th>
+              <th>Código</th>
+              <th>Descripción</th>
+              <th>Unidad</th>
+              <th>Factor</th>
+              <th>Cantidad</th>
+              <th>Precio</th>
+              <th>Total</th>
+              <th></th>
             </tr>
           </thead>
           <tbody id="cartItemsDesktop"></tbody>


### PR DESCRIPTION
## Summary
- Reorder desktop cart header to include Código, Descripción, Unidad, Factor, Cantidad, Precio y Total
- Show unidad and factor columns for cart items in both desktop and mobile views
- Expand empty-cart message to match new column count

## Testing
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68aedf0f89d883249a5a5e60e541b7a3