### PR TITLE
Add payment simulator page and config routes

### DIFF
--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -3072,15 +3072,15 @@ function openPaymentSimulator() {
         const modalEl = document.getElementById('paymentSimulatorModal');
         const frame = document.getElementById('paymentSimulatorFrame');
         if (!modalEl || !frame || typeof bootstrap === 'undefined' || !bootstrap.Modal) {
-            window.open(`/simulador/?total=${total}`, '_blank');
+            window.open(`/payments/simulator/?total=${total}`, '_blank');
             return;
         }
-        frame.src = `/simulador/?total=${total}`;
+        frame.src = `/payments/simulator/?total=${total}`;
         const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
         modal.show();
     } catch (err) {
         console.error('Error al abrir simulador de pagos:', err);
-        window.open(`/simulador/?total=${total}`, '_blank');
+        window.open(`/payments/simulator/?total=${total}`, '_blank');
     }
 }
 

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -52,6 +52,7 @@
           <a href="{% url 'core:secuencias_list' %}" class="nav-link text-light">Secuencias</a>
           <a href="{% url 'core:tipos_contribuyente_list' %}" class="nav-link text-light">Tipos de Contribuyente</a>
           <a href="{% url 'core:modo_entrega_list' %}" class="nav-link text-light">Modos de Entrega</a>
+          <a href="{% url 'core:payments_config' %}" class="nav-link text-light">Pagos</a>
         {% endif %}
         {% if request.user.is_authenticated %}
           <span class="navbar-text text-light session-info">Hola, {{ request.session.usuario }}</span>

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 # core/urls.py
 from django.urls import path
 from . import views
+from payments import views as payment_views
 
 app_name = "core"
 
@@ -57,4 +58,6 @@ urlpatterns = [
     path('config/modos-entrega/<int:pk>/editar/', views.modo_entrega_update, name='modo_entrega_update'),
     path('config/modos-entrega/<int:pk>/eliminar/', views.modo_entrega_delete, name='modo_entrega_delete'),
 
+    path('payments/simulator/', payment_views.simulator_page, name='payment_simulator'),
+    path('payments/config/', payment_views.config_index, name='payments_config'),
 ]

--- a/payments/forms.py
+++ b/payments/forms.py
@@ -1,0 +1,28 @@
+from django import forms
+from .models import PaymentMethod, CardBrand, CreditPlan
+
+
+class PaymentMethodForm(forms.ModelForm):
+    class Meta:
+        model = PaymentMethod
+        fields = ["code", "label", "enabled", "sort_order"]
+
+
+class CardBrandForm(forms.ModelForm):
+    class Meta:
+        model = CardBrand
+        fields = ["name", "enabled"]
+
+
+class CreditPlanForm(forms.ModelForm):
+    class Meta:
+        model = CreditPlan
+        fields = [
+            "brand",
+            "installments",
+            "coef_total",
+            "coef_cuota",
+            "enabled",
+            "valid_from",
+            "valid_to",
+        ]

--- a/payments/templates/payments/config/index.html
+++ b/payments/templates/payments/config/index.html
@@ -1,0 +1,8 @@
+{% extends 'layout.html' %}
+{% block title %}Configuración de Pagos{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>Configuración de Pagos</h1>
+  <p>Pantallas de configuración de métodos de pago pendientes de implementación.</p>
+</div>
+{% endblock %}

--- a/payments/templates/payments/simulator.html
+++ b/payments/templates/payments/simulator.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block title %}Simulador de Pagos{% endblock %}
+{% block content %}
+<div class="container">
+  <h1>Simulador de Pagos</h1>
+  <p>Total a simular: {{ total }}</p>
+  <p>Esta es la nueva versión del simulador de pagos.</p>
+</div>
+{% endblock %}

--- a/payments/views.py
+++ b/payments/views.py
@@ -4,6 +4,9 @@ from django.http import JsonResponse, HttpResponseBadRequest
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 from django.forms.models import model_to_dict
+from django.shortcuts import render
+from django.contrib.auth.decorators import login_required, permission_required
+
 
 from .models import (
     PaymentMethod,
@@ -195,3 +198,15 @@ def get_simulation(request, pk: int):
         for item in simulation.items.all().order_by("sort_order")
     ]
     return JsonResponse(data)
+
+@login_required
+def simulator_page(request):
+    total = request.GET.get("total", "0")
+    return render(request, "payments/simulator.html", {"total": total})
+
+
+@login_required
+@permission_required("payments.view_paymentmethod", raise_exception=True)
+def config_index(request):
+    return render(request, "payments/config/index.html")
+


### PR DESCRIPTION
## Summary
- Redirect cart's payment simulator button to new `/payments/simulator` view
- Expose basic payment configuration route and placeholder template
- Add initial forms and templates for upcoming payment simulator features

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b04e3f73148324aded527dcabe26b7